### PR TITLE
Fix output order of `Ignore` segments

### DIFF
--- a/src/DslPackage/TextTemplates/EFCoreDesigner.ttinclude
+++ b/src/DslPackage/TextTemplates/EFCoreDesigner.ttinclude
@@ -271,6 +271,9 @@ void WriteDbContextEFCore(ModelRoot modelRoot)
       // class level
       segments.Add($"modelBuilder.{(modelClass.IsDependentType ? "Owned" : "Entity")}<{modelClass.FullName}>()");
 
+      foreach (ModelAttribute transient in modelClass.Attributes.Where(x => !x.Persistent))
+         segments.Add($"Ignore(t => t.{transient.Name})");
+
       if (!modelClass.IsDependentType)
       {
          // note: this must come before the 'ToTable' call or there's a runtime error
@@ -292,9 +295,6 @@ void WriteDbContextEFCore(ModelRoot modelRoot)
                segments.Add($"HasKey(t => new {{ t.{string.Join(", t.", identityAttributes.Select(ia => ia.Name))} }})");
          }
       }
-
-      foreach (ModelAttribute transient in modelClass.Attributes.Where(x => !x.Persistent))
-         segments.Add($"Ignore(t => t.{transient.Name})");
 
       if (segments.Count > 1 || modelClass.IsDependentType)
       {


### PR DESCRIPTION
This PR fixes issue #115.

It fixes the bug by outputting `Ignore` segments before `HasKey`. It also makes `Ignore` segments appear immediately after `modelBuilder.Entity<T>()` and before `ToTable(...)` (which may or may not be what you intend).

Example of the output generated with this change:

```cs
modelBuilder.Entity<global::Foo.Bar>()
                     .Ignore(t => t.A)
                     .Ignore(t => t.B)
                     .ToTable("Bar")
                     .HasKey(t => t.Id);
```