### PR TITLE
Automatically normalize line endings (via `.gitattributes` file)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior to automatically normalize line endings.
+* text=auto


### PR DESCRIPTION
Hi, this PR fixes part of #117: `GeneratedVSCT.tt` generates an invalid file (a file that starts with blank lines) because of LF (Unix-style) line endings.

This PR fixes the issue by introducing a configuration that sets Git's default behavior to automatically normalize line endings (according to its heuristics of what is a text file and what's not).

More info:
[1] - https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/
[2] - https://rehansaeed.com/gitattributes-best-practices/
[3] - https://git-scm.com/docs/gitattributes